### PR TITLE
chore: rename to newrelic-experimental

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,28 +1,28 @@
 name: "Prepare the release"
 on:
   push:
-    tags: [ 'v*' ]
+    tags: ["v*"]
 
 jobs:
   release:
     runs-on: ubuntu-20.04
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: "1.20"
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: "generate release resources"
-      run: make release-artifacts IMG_PREFIX="ghcr.io/andrew-lozoya/newrelic-agent-operator"
+      - name: "generate release resources"
+        run: make release-artifacts IMG_PREFIX="ghcr.io/newrelic-experimental/newrelic-agent-operator"
 
-    - name: "create the release in GitHub"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./.ci/create-release-github.sh
+      - name: "create the release in GitHub"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.ci/create-release-github.sh
 
-    - name: "refresh go proxy module info on release"
-      run: |
-        OPERATOR_VERSION=$(git describe --tags)
-        curl https://proxy.golang.org/github.com/andrew-lozoya/newrelic-agent-operator/@v/${OPERATOR_VERSION}.info
+      - name: "refresh go proxy module info on release"
+        run: |
+          OPERATOR_VERSION=$(git describe --tags)
+          curl https://proxy.golang.org/github.com/newrelic-experimental/newrelic-agent-operator/@v/${OPERATOR_VERSION}.info

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= "$(shell git describe --tags | sed 's/^v//')"
 VERSION_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-VERSION_PKG ?= "github.com/andrew-lozoya/newrelic-aganet-operator/internal/version"
+VERSION_PKG ?= "github.com/newrelic-experimental/newrelic-aganet-operator/internal/version"
 OPERATOR_VERSION ?= "$(shell grep -v '\#' versions.txt | grep newrelic-agent-operator | awk -F= '{print $$2}')"
 NEWRELIC_INSTRUMENTATION_JAVA_VERSION ?= "$(shell grep -v '\#' versions.txt | grep newrelic-instrumentation-java | awk -F= '{print $$2}')"
 NEWRELIC_INSTRUMENTATION_NODEJS_VERSION ?= "$(shell grep -v '\#' versions.txt | grep newrelic-instrumentation-nodejs | awk -F= '{print $$2}')"

--- a/PROJECT
+++ b/PROJECT
@@ -4,22 +4,22 @@
 # More info: https://book.kubebuilder.io/reference/project-config.html
 domain: newrelic.com
 layout:
-- go.kubebuilder.io/v4-alpha
+  - go.kubebuilder.io/v4-alpha
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: newrelic-agent-operator
-repo: github.com/andrew-lozoya/newrelic-agent-operator
+repo: github.com/newrelic-experimental/newrelic-agent-operator
 resources:
-- api:
-    crdVersion: v1
-    namespaced: true
-  domain: newrelic.com
-  kind: Instrumentation
-  path: github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1
-  version: v1alpha1
-  webhooks:
-    defaulting: true
-    validation: true
-    webhookVersion: v1
+  - api:
+      crdVersion: v1
+      namespaced: true
+    domain: newrelic.com
+    kind: Instrumentation
+    path: github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1
+    version: v1alpha1
+    webhooks:
+      defaulting: true
+      validation: true
+      webhookVersion: v1
 version: "3"

--- a/bundle/manifests/newrelic-agent-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/newrelic-agent-operator.clusterserviceversion.yaml
@@ -12,16 +12,16 @@ metadata:
           },
           "spec": {
             "dotnet": {
-              "image": "ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-dotnet:latest"
+              "image": "ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-dotnet:latest"
             },
             "java": {
-              "image": "ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-java:latest"
+              "image": "ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-java:latest"
             },
             "nodejs": {
-              "image": "ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-nodejs:latest"
+              "image": "ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-nodejs:latest"
             },
             "python": {
-              "image": "ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-python:latest"
+              "image": "ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-python:latest"
             }
           }
         }
@@ -36,300 +36,301 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Instrumentation is the Schema for the instrumentations API
-      displayName: New Relic Instrumentation
-      kind: Instrumentation
-      name: instrumentations.newrelic.com
-      resources:
-      - kind: Pod
-        name: ""
-        version: v1
-      version: v1alpha1
-  description: The New Relic agent operator is an admission controller API that enables
+      - description: Instrumentation is the Schema for the instrumentations API
+        displayName: New Relic Instrumentation
+        kind: Instrumentation
+        name: instrumentations.newrelic.com
+        resources:
+          - kind: Pod
+            name: ""
+            version: v1
+        version: v1alpha1
+  description:
+    The New Relic agent operator is an admission controller API that enables
     the instrumentation of application workloads (including Java, NodeJS, DotNet,
     and Python) using a custom resource definition.
   displayName: New Relic Agent Operator
   icon:
-  - base64data: "PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MTkgMTU4Ljk3Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6IzAwYWM2OTt9LmNscy0ye2ZpbGw6IzFjZTc4Mzt9LmNscy0ze2ZpbGw6IzFkMjUyYzt9PC9zdHlsZT48L2RlZnM+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjExMS4xOSA1NS4wMyAxMTEuMTkgMTAzLjk0IDY4Ljg0IDEyOC40IDY4Ljg0IDE1OC45NyAxMzcuNjggMTE5LjIzIDEzNy42OCAzOS43NCAxMTEuMTkgNTUuMDMiLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iNjguODQgMzAuNTggMTExLjE5IDU1LjAzIDEzNy42OCAzOS43NCAxMzcuNjggMzkuNzQgNjguODQgMCAwIDM5Ljc0IDAgMzkuNzQgMjYuNDggNTUuMDMgNjguODQgMzAuNTgiLz48cG9seWdvbiBjbGFzcz0iY2xzLTMiIHBvaW50cz0iNDIuMzYgOTQuNzggNDIuMzYgMTQzLjY5IDY4Ljg0IDE1OC45NyA2OC44NCA3OS40OSAwIDM5Ljc0IDAgNzAuMzIgNDIuMzYgOTQuNzgiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNDIuMTcsNTAuMTRjLTE0LjgyLDAtMjEuODQsOS4zNi0yMS44NCw5LjM2aC0uNzhMMjE4LDUxLjdIMjAwLjA1djc5LjU2aDE5LjV2LTQ2YzAtMTAuMTQsNy0xNy4xNiwxNy4xNi0xNy4xNnMxNy4xNiw3LDE3LjE2LDE3LjE2djQ2aDE5LjVWODMuNjhDMjczLjM3LDYzLjQsMjYwLjExLDUwLjE0LDI0Mi4xNyw1MC4xNFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBvbHlnb24gY2xhc3M9ImNscy0zIiBwb2ludHM9IjQ0Mi40NyA5My40NSA0NDEuMzUgOTMuNDUgNDI4LjA5IDQxLjE5IDQwOC4yNSA0MS4xOSAzOTQuOTkgOTMuNDUgMzkzLjg4IDkzLjQ1IDM4MC42MSA0MS4xOSAzNjAuMzMgNDEuMTkgMzgwLjYxIDEyMC43NSA0MDQuMzYgMTIwLjc1IDQxNy42MSA2OS4yNyA0MTguNzMgNjkuMjcgNDMxLjk5IDEyMC43NSA0NTUuNzMgMTIwLjc1IDQ3Ni4wMSA0MS4xOSA0NTUuNzMgNDEuMTkgNDQyLjQ3IDkzLjQ1Ii8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNTQ1LjcyLDU4LjcyaC0uNzhsLTEuNTYtN0g1Mjd2NzkuNTVoMTkuNXYtNDZjMC0xMC4xNCw0LjY4LTE0LjgyLDE0LjgyLTE0LjgyaDEwVjUxLjcxaC0xMS42QTE3LjU2LDE3LjU2LDAsMCwwLDU0NS43Miw1OC43MloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNjE0LjQ3LDUwLjE0Yy0yMy4zOSwwLTQwLjU1LDE3LjE2LTQwLjU1LDQxLjM0czE2LjE5LDQxLjM0LDQwLjU1LDQxLjM0YzE5LjczLDAsMzEuNjEtMTEuNjEsMzYuNTYtMjAuMTVsLTE3LjktNi4zOGMtMS43NywzLjI0LTguOTEsOS40Ny0xOC42Niw5LjQ3LTExLjM3LDAtMTkuNDktNy4xMi0yMS4wNS0xOGg1OS4yN2EzNS4zOCwzNS4zOCwwLDAsMCwuNzgtNy44QzY1My40Nyw2Ny4zLDYzNi4zMSw1MC4xNCw2MTQuNDcsNTAuMTRaTTU5My40Miw4NC40NmMyLjM0LTEwLjE0LDkuMzYtMTcuOTQsMjEuMDUtMTcuOTQsMTAuOTMsMCwxNy45NCw3LjgsMTkuNSwxNy45NFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMzI2LjQsNTAuMTRjLTIzLjQsMC00MC41NiwxNy4xNi00MC41Niw0MS4zNFMzMDIsMTMyLjgyLDMyNi40LDEzMi44MmMxOS43MywwLDMxLjYtMTEuNjEsMzYuNTUtMjAuMTVsLTE3LjktNi4zOGMtMS43NywzLjI0LTguOSw5LjQ3LTE4LjY1LDkuNDctMTEuMzcsMC0xOS41LTcuMTItMjEuMDYtMThoNTkuMjhhMzUuMzgsMzUuMzgsMCwwLDAsLjc4LTcuOEMzNjUuNCw2Ny4zLDM0OC4yNCw1MC4xNCwzMjYuNCw1MC4xNFpNMzA1LjM0LDg0LjQ2YzIuMzQtMTAuMTQsOS4zNi0xNy45NCwyMS4wNi0xNy45NCwxMC45MiwwLDE3Ljk0LDcuOCwxOS41LDE3Ljk0WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwIC0xMC41MSkiLz48cmVjdCBjbGFzcz0iY2xzLTMiIHg9IjY5Mi4xNCIgeT0iOS43OCIgd2lkdGg9IjE5LjUiIGhlaWdodD0iMTkuNSIvPjxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTc3NS40NSwxMTQuODhjLTExLjcsMC0yMS4wNi05LjM2LTIxLjA2LTIzLjRzOS4zNi0yMy40LDIxLjA2LTIzLjQsMTYuMzgsNy44LDE3Ljk0LDEyLjQ4bDE3LjY2LTYuMjhjLTQuMjgtMTEuMTEtMTQuNzgtMjQuMTQtMzUuNi0yNC4xNC0yMy40LDAtNDAuNTYsMTcuMTYtNDAuNTYsNDEuMzRzMTcuMTYsNDEuMzQsNDAuNTYsNDEuMzRjMjEsMCwzMS41LTEzLjI0LDM1LjctMjQuODhsLTE3Ljc2LTYuMzJDNzkxLjgzLDEwNy4wOCw3ODcuMTUsMTE0Ljg4LDc3NS40NSwxMTQuODhaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTAgLTEwLjUxKSIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI2NDUuNjMgMjcuMTEgNjU2LjcgMjcuMTEgNjU2LjcgMTIwLjc1IDY3Ni4yIDEyMC43NSA2NzYuMiA5Ljc4IDY0NS42MyA5Ljc4IDY0NS42MyAyNy4xMSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iNjkyLjE0IiB5PSI0MS4xOSIgd2lkdGg9IjE5LjUiIGhlaWdodD0iNzkuNTYiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik04MjEuNTksMTE2YTcuNTIsNy41MiwwLDEsMCw3LjQxLDcuNTJBNy4yOCw3LjI4LDAsMCwwLDgyMS41OSwxMTZabTAsMTMuODlhNi4zNyw2LjM3LDAsMSwxLDYuMjYtNi4zN0E2LjEyLDYuMTIsMCwwLDEsODIxLjU5LDEyOS44NVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNODI0LjgyLDEyMi4xM2EyLjY0LDIuNjQsMCwwLDAtMi44Mi0yLjYyaC0zLjM0djcuODRoMS4xNXYtMi43MmgxLjA1bDIuNzEsMi43Mkg4MjVsLTIuNzEtMi43MkEyLjUzLDIuNTMsMCwwLDAsODI0LjgyLDEyMi4xM1ptLTUsMS4zNXYtMi44Mkg4MjJhMS41LDEuNSwwLDAsMSwxLjY4LDEuNDdjMCwuODMtLjUzLDEuMzUtMS42OCwxLjM1WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwIC0xMC41MSkiLz48L3N2Zz4="
-    mediatype: "image/svg+xml"
+    - base64data: "PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MTkgMTU4Ljk3Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6IzAwYWM2OTt9LmNscy0ye2ZpbGw6IzFjZTc4Mzt9LmNscy0ze2ZpbGw6IzFkMjUyYzt9PC9zdHlsZT48L2RlZnM+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjExMS4xOSA1NS4wMyAxMTEuMTkgMTAzLjk0IDY4Ljg0IDEyOC40IDY4Ljg0IDE1OC45NyAxMzcuNjggMTE5LjIzIDEzNy42OCAzOS43NCAxMTEuMTkgNTUuMDMiLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iNjguODQgMzAuNTggMTExLjE5IDU1LjAzIDEzNy42OCAzOS43NCAxMzcuNjggMzkuNzQgNjguODQgMCAwIDM5Ljc0IDAgMzkuNzQgMjYuNDggNTUuMDMgNjguODQgMzAuNTgiLz48cG9seWdvbiBjbGFzcz0iY2xzLTMiIHBvaW50cz0iNDIuMzYgOTQuNzggNDIuMzYgMTQzLjY5IDY4Ljg0IDE1OC45NyA2OC44NCA3OS40OSAwIDM5Ljc0IDAgNzAuMzIgNDIuMzYgOTQuNzgiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNDIuMTcsNTAuMTRjLTE0LjgyLDAtMjEuODQsOS4zNi0yMS44NCw5LjM2aC0uNzhMMjE4LDUxLjdIMjAwLjA1djc5LjU2aDE5LjV2LTQ2YzAtMTAuMTQsNy0xNy4xNiwxNy4xNi0xNy4xNnMxNy4xNiw3LDE3LjE2LDE3LjE2djQ2aDE5LjVWODMuNjhDMjczLjM3LDYzLjQsMjYwLjExLDUwLjE0LDI0Mi4xNyw1MC4xNFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBvbHlnb24gY2xhc3M9ImNscy0zIiBwb2ludHM9IjQ0Mi40NyA5My40NSA0NDEuMzUgOTMuNDUgNDI4LjA5IDQxLjE5IDQwOC4yNSA0MS4xOSAzOTQuOTkgOTMuNDUgMzkzLjg4IDkzLjQ1IDM4MC42MSA0MS4xOSAzNjAuMzMgNDEuMTkgMzgwLjYxIDEyMC43NSA0MDQuMzYgMTIwLjc1IDQxNy42MSA2OS4yNyA0MTguNzMgNjkuMjcgNDMxLjk5IDEyMC43NSA0NTUuNzMgMTIwLjc1IDQ3Ni4wMSA0MS4xOSA0NTUuNzMgNDEuMTkgNDQyLjQ3IDkzLjQ1Ii8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNTQ1LjcyLDU4LjcyaC0uNzhsLTEuNTYtN0g1Mjd2NzkuNTVoMTkuNXYtNDZjMC0xMC4xNCw0LjY4LTE0LjgyLDE0LjgyLTE0LjgyaDEwVjUxLjcxaC0xMS42QTE3LjU2LDE3LjU2LDAsMCwwLDU0NS43Miw1OC43MloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNjE0LjQ3LDUwLjE0Yy0yMy4zOSwwLTQwLjU1LDE3LjE2LTQwLjU1LDQxLjM0czE2LjE5LDQxLjM0LDQwLjU1LDQxLjM0YzE5LjczLDAsMzEuNjEtMTEuNjEsMzYuNTYtMjAuMTVsLTE3LjktNi4zOGMtMS43NywzLjI0LTguOTEsOS40Ny0xOC42Niw5LjQ3LTExLjM3LDAtMTkuNDktNy4xMi0yMS4wNS0xOGg1OS4yN2EzNS4zOCwzNS4zOCwwLDAsMCwuNzgtNy44QzY1My40Nyw2Ny4zLDYzNi4zMSw1MC4xNCw2MTQuNDcsNTAuMTRaTTU5My40Miw4NC40NmMyLjM0LTEwLjE0LDkuMzYtMTcuOTQsMjEuMDUtMTcuOTQsMTAuOTMsMCwxNy45NCw3LjgsMTkuNSwxNy45NFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMzI2LjQsNTAuMTRjLTIzLjQsMC00MC41NiwxNy4xNi00MC41Niw0MS4zNFMzMDIsMTMyLjgyLDMyNi40LDEzMi44MmMxOS43MywwLDMxLjYtMTEuNjEsMzYuNTUtMjAuMTVsLTE3LjktNi4zOGMtMS43NywzLjI0LTguOSw5LjQ3LTE4LjY1LDkuNDctMTEuMzcsMC0xOS41LTcuMTItMjEuMDYtMThoNTkuMjhhMzUuMzgsMzUuMzgsMCwwLDAsLjc4LTcuOEMzNjUuNCw2Ny4zLDM0OC4yNCw1MC4xNCwzMjYuNCw1MC4xNFpNMzA1LjM0LDg0LjQ2YzIuMzQtMTAuMTQsOS4zNi0xNy45NCwyMS4wNi0xNy45NCwxMC45MiwwLDE3Ljk0LDcuOCwxOS41LDE3Ljk0WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwIC0xMC41MSkiLz48cmVjdCBjbGFzcz0iY2xzLTMiIHg9IjY5Mi4xNCIgeT0iOS43OCIgd2lkdGg9IjE5LjUiIGhlaWdodD0iMTkuNSIvPjxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTc3NS40NSwxMTQuODhjLTExLjcsMC0yMS4wNi05LjM2LTIxLjA2LTIzLjRzOS4zNi0yMy40LDIxLjA2LTIzLjQsMTYuMzgsNy44LDE3Ljk0LDEyLjQ4bDE3LjY2LTYuMjhjLTQuMjgtMTEuMTEtMTQuNzgtMjQuMTQtMzUuNi0yNC4xNC0yMy40LDAtNDAuNTYsMTcuMTYtNDAuNTYsNDEuMzRzMTcuMTYsNDEuMzQsNDAuNTYsNDEuMzRjMjEsMCwzMS41LTEzLjI0LDM1LjctMjQuODhsLTE3Ljc2LTYuMzJDNzkxLjgzLDEwNy4wOCw3ODcuMTUsMTE0Ljg4LDc3NS40NSwxMTQuODhaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTAgLTEwLjUxKSIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI2NDUuNjMgMjcuMTEgNjU2LjcgMjcuMTEgNjU2LjcgMTIwLjc1IDY3Ni4yIDEyMC43NSA2NzYuMiA5Ljc4IDY0NS42MyA5Ljc4IDY0NS42MyAyNy4xMSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iNjkyLjE0IiB5PSI0MS4xOSIgd2lkdGg9IjE5LjUiIGhlaWdodD0iNzkuNTYiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik04MjEuNTksMTE2YTcuNTIsNy41MiwwLDEsMCw3LjQxLDcuNTJBNy4yOCw3LjI4LDAsMCwwLDgyMS41OSwxMTZabTAsMTMuODlhNi4zNyw2LjM3LDAsMSwxLDYuMjYtNi4zN0E2LjEyLDYuMTIsMCwwLDEsODIxLjU5LDEyOS44NVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMCAtMTAuNTEpIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNODI0LjgyLDEyMi4xM2EyLjY0LDIuNjQsMCwwLDAtMi44Mi0yLjYyaC0zLjM0djcuODRoMS4xNXYtMi43MmgxLjA1bDIuNzEsMi43Mkg4MjVsLTIuNzEtMi43MkEyLjUzLDIuNTMsMCwwLDAsODI0LjgyLDEyMi4xM1ptLTUsMS4zNXYtMi44Mkg4MjJhMS41LDEuNSwwLDAsMSwxLjY4LDEuNDdjMCwuODMtLjUzLDEuMzUtMS42OCwxLjM1WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwIC0xMC41MSkiLz48L3N2Zz4="
+      mediatype: "image/svg+xml"
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - create
-          - get
-          - list
-          - update
-        - apiGroups:
-          - newrelic.com
-          resources:
-          - instrumentations
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          - routes/custom-host
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        serviceAccountName: newrelic-agent-operator-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - list
+                - update
+            - apiGroups:
+                - newrelic.com
+              resources:
+                - instrumentations
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: newrelic-agent-operator-controller-manager
       deployments:
-      - label:
-          app.kubernetes.io/name: newrelic-agent-operator
-          control-plane: controller-manager
-        name: newrelic-agent-operator-controller-manager
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app.kubernetes.io/name: newrelic-agent-operator
-              control-plane: controller-manager
-          strategy: {}
-          template:
-            metadata:
-              labels:
+        - label:
+            app.kubernetes.io/name: newrelic-agent-operator
+            control-plane: controller-manager
+          name: newrelic-agent-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 app.kubernetes.io/name: newrelic-agent-operator
                 control-plane: controller-manager
-            spec:
-              containers:
-              - args:
-                - --metrics-addr=127.0.0.1:8080
-                - --enable-leader-election
-                - --zap-log-level=info
-                - --zap-time-encoding=rfc3339nano
-                image: ghcr.io/andrew-lozoya/newrelic-agent-operator/newrelic-agent-operator:0.0.3
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                ports:
-                - containerPort: 9443
-                  name: webhook-server
-                  protocol: TCP
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  requests:
-                    cpu: 100m
-                    memory: 64Mi
-                volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
-                  name: cert
-                  readOnly: true
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-              serviceAccountName: newrelic-agent-operator-controller-manager
-              terminationGracePeriodSeconds: 10
-              volumes:
-              - name: cert
-                secret:
-                  defaultMode: 420
-                  secretName: newrelic-agent-operator-controller-manager-service-cert
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: newrelic-agent-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-addr=127.0.0.1:8080
+                      - --enable-leader-election
+                      - --zap-log-level=info
+                      - --zap-time-encoding=rfc3339nano
+                    image: ghcr.io/newrelic-experimental/newrelic-agent-operator/newrelic-agent-operator:0.0.3
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 64Mi
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                serviceAccountName: newrelic-agent-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: newrelic-agent-operator-controller-manager-service-cert
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps/status
-          verbs:
-          - get
-          - update
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        serviceAccountName: newrelic-agent-operator-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: newrelic-agent-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - newrelic
-  - instrumentation
-  - apm
+    - newrelic
+    - instrumentation
+    - apm
   links:
-  - name: Newrelic Agent Operator
-    url: https://newrelic-agent-operator.domain
+    - name: Newrelic Agent Operator
+      url: https://newrelic-agent-operator.domain
   maintainers:
-  - email: alozoya@newrelic.com
-    name: Andrew Lozoya
+    - email: alozoya@newrelic.com
+      name: Andrew Lozoya
   maturity: alpha
   provider:
     name: New Relic
     url: newrelic.com
   version: 0.0.3
   webhookdefinitions:
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: newrelic-agent-operator-controller-manager
-    failurePolicy: Fail
-    generateName: minstrumentation.kb.io
-    rules:
-    - apiGroups:
-      - newrelic.com
-      apiVersions:
-      - v1alpha1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - instrumentations
-    sideEffects: None
-    targetPort: 9443
-    type: MutatingAdmissionWebhook
-    webhookPath: /mutate-newrelic-com-v1alpha1-instrumentation
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: newrelic-agent-operator-controller-manager
-    failurePolicy: Ignore
-    generateName: mpod.kb.io
-    rules:
-    - apiGroups:
-      - ""
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - pods
-    sideEffects: None
-    targetPort: 9443
-    type: MutatingAdmissionWebhook
-    webhookPath: /mutate-v1-pod
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: newrelic-agent-operator-controller-manager
-    failurePolicy: Fail
-    generateName: vinstrumentationcreateupdate.kb.io
-    rules:
-    - apiGroups:
-      - newrelic.com
-      apiVersions:
-      - v1alpha1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - instrumentations
-    sideEffects: None
-    targetPort: 9443
-    type: ValidatingAdmissionWebhook
-    webhookPath: /validate-newrelic-com-v1alpha1-instrumentation
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: newrelic-agent-operator-controller-manager
-    failurePolicy: Ignore
-    generateName: vinstrumentationdelete.kb.io
-    rules:
-    - apiGroups:
-      - newrelic.com
-      apiVersions:
-      - v1alpha1
-      operations:
-      - DELETE
-      resources:
-      - instrumentations
-    sideEffects: None
-    targetPort: 9443
-    type: ValidatingAdmissionWebhook
-    webhookPath: /validate-newrelic-com-v1alpha1-instrumentation
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: newrelic-agent-operator-controller-manager
+      failurePolicy: Fail
+      generateName: minstrumentation.kb.io
+      rules:
+        - apiGroups:
+            - newrelic.com
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - instrumentations
+      sideEffects: None
+      targetPort: 9443
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-newrelic-com-v1alpha1-instrumentation
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: newrelic-agent-operator-controller-manager
+      failurePolicy: Ignore
+      generateName: mpod.kb.io
+      rules:
+        - apiGroups:
+            - ""
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - pods
+      sideEffects: None
+      targetPort: 9443
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-v1-pod
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: newrelic-agent-operator-controller-manager
+      failurePolicy: Fail
+      generateName: vinstrumentationcreateupdate.kb.io
+      rules:
+        - apiGroups:
+            - newrelic.com
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - instrumentations
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-newrelic-com-v1alpha1-instrumentation
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: newrelic-agent-operator-controller-manager
+      failurePolicy: Ignore
+      generateName: vinstrumentationdelete.kb.io
+      rules:
+        - apiGroups:
+            - newrelic.com
+          apiVersions:
+            - v1alpha1
+          operations:
+            - DELETE
+          resources:
+            - instrumentations
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-newrelic-com-v1alpha1-instrumentation

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,7 +18,7 @@ controllerManager:
   ## Provide New Relic Agent Operator manager container image and resources.
   manager:
     image:
-      repository: ghcr.io/andrew-lozoya/newrelic-agent-operator/newrelic-agent-operator
+      repository: ghcr.io/newrelic-experimental/newrelic-agent-operator/newrelic-agent-operator
       tag: v0.0.4
     resources:
       requests:
@@ -37,16 +37,16 @@ controllerManager:
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
   type: ClusterIP
 webhookService:
   ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 9443
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
   type: ClusterIP
 
 ## SecurityContext holds pod-level security attributes and common container settings.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,13 +41,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	v1alpha1 "github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/config"
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/version"
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/webhookhandler"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/autodetect"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/instrumentation"
-	instrumentationupgrade "github.com/andrew-lozoya/newrelic-agent-operator/pkg/instrumentation/upgrade"
+	v1alpha1 "github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/config"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/version"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/webhookhandler"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/autodetect"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/instrumentation"
+	instrumentationupgrade "github.com/newrelic-experimental/newrelic-agent-operator/pkg/instrumentation/upgrade"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -96,10 +96,10 @@ func main() {
 	pflag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	pflag.StringVar(&autoInstrumentationJava, "auto-instrumentation-java-image", fmt.Sprintf("ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-java:%s", v.AutoInstrumentationJava), "The default New Relic Java instrumentation image. This image is used when no image is specified in the CustomResource.")
-	pflag.StringVar(&autoInstrumentationNodeJS, "auto-instrumentation-nodejs-image", fmt.Sprintf("ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-nodejs:%s", v.AutoInstrumentationNodeJS), "The default New Relic NodeJS instrumentation image. This image is used when no image is specified in the CustomResource.")
-	pflag.StringVar(&autoInstrumentationPython, "auto-instrumentation-python-image", fmt.Sprintf("ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-python:%s", v.AutoInstrumentationPython), "The default New Relic Python instrumentation image. This image is used when no image is specified in the CustomResource.")
-	pflag.StringVar(&autoInstrumentationDotNet, "auto-instrumentation-dotnet-image", fmt.Sprintf("ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-dotnet:%s", v.AutoInstrumentationDotNet), "The default New Relic DotNet instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoInstrumentationJava, "auto-instrumentation-java-image", fmt.Sprintf("ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-java:%s", v.AutoInstrumentationJava), "The default New Relic Java instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoInstrumentationNodeJS, "auto-instrumentation-nodejs-image", fmt.Sprintf("ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-nodejs:%s", v.AutoInstrumentationNodeJS), "The default New Relic NodeJS instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoInstrumentationPython, "auto-instrumentation-python-image", fmt.Sprintf("ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-python:%s", v.AutoInstrumentationPython), "The default New Relic Python instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoInstrumentationDotNet, "auto-instrumentation-dotnet-image", fmt.Sprintf("ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-dotnet:%s", v.AutoInstrumentationDotNet), "The default New Relic DotNet instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.StringArrayVar(&labelsFilter, "labels", []string{}, "Labels to filter away from propagating onto deploys")
 	pflag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to.")
 	pflag.StringVar(&tlsOpt.minVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- manager.yaml
+  - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: ghcr.io/andrew-lozoya/newrelic-agent-operator/newrelic-agent-operator
-  newTag: 0.0.3
+  - name: controller
+    newName: ghcr.io/newrelic-experimental/newrelic-agent-operator/newrelic-agent-operator
+    newTag: 0.0.3

--- a/config/samples/instrumentation_v1alpha1_instrumentation.yaml
+++ b/config/samples/instrumentation_v1alpha1_instrumentation.yaml
@@ -4,10 +4,10 @@ metadata:
   name: newrelic-instrumentation
 spec:
   java:
-    image: ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-java:latest
+    image: ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-java:latest
   nodejs:
-    image: ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-nodejs:latest
+    image: ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-nodejs:latest
   python:
-    image: ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-python:latest
+    image: ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-python:latest
   dotnet:
-    image: ghcr.io/andrew-lozoya/newrelic-agent-operator/instrumentation-dotnet:latest
+    image: ghcr.io/newrelic-experimental/newrelic-agent-operator/instrumentation-dotnet:latest

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/andrew-lozoya/newrelic-agent-operator
+module github.com/newrelic-experimental/newrelic-agent-operator
 
 go 1.20
 

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -23,8 +23,8 @@ import (
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/version"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/autodetect"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/version"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/autodetect"
 )
 
 const (

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/config"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/autodetect"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/config"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/autodetect"
 )
 
 func TestNewConfig(t *testing.T) {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/version"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/autodetect"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/version"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/autodetect"
 )
 
 // Option represents one specific configuration option.

--- a/internal/webhookhandler/webhookhandler.go
+++ b/internal/webhookhandler/webhookhandler.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/config"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/config"
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,sideEffects=none,admissionReviewVersions=v1

--- a/internal/webhookhandler/webhookhandler_suite_test.go
+++ b/internal/webhookhandler/webhookhandler_suite_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/autodetect/main_test.go
+++ b/pkg/autodetect/main_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/autodetect"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/autodetect"
 )
 
 func TestDetectPlatformBasedOnAvailableAPIGroups(t *testing.T) {

--- a/pkg/instrumentation/dotnet.go
+++ b/pkg/instrumentation/dotnet.go
@@ -21,7 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 const (

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -18,7 +18,7 @@ package instrumentation
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 const (

--- a/pkg/instrumentation/nodejs.go
+++ b/pkg/instrumentation/nodejs.go
@@ -18,7 +18,7 @@ package instrumentation
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 const (

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
-	"github.com/andrew-lozoya/newrelic-agent-operator/internal/webhookhandler"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/internal/webhookhandler"
 )
 
 var (

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -20,7 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 const (

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -26,8 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
-	"github.com/andrew-lozoya/newrelic-agent-operator/pkg/constants"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/pkg/constants"
 )
 
 const (

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 type InstrumentationUpgrade struct {

--- a/pkg/instrumentation/upgrade/upgrade_suite_test.go
+++ b/pkg/instrumentation/upgrade/upgrade_suite_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 var k8sClient client.Client

--- a/pkg/instrumentation/upgrade/upgrade_test.go
+++ b/pkg/instrumentation/upgrade/upgrade_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/andrew-lozoya/newrelic-agent-operator/api/v1alpha1"
+	"github.com/newrelic-experimental/newrelic-agent-operator/api/v1alpha1"
 )
 
 func TestUpgrade(t *testing.T) {


### PR DESCRIPTION
Update all package/module refs to use `newrelic-experimental`

## Todo

I updated image refs to point to newrelic-experimental as well. Because of this, we should enable the CI workflows to publish images to ghcr. Just need to test this out after merging to make sure it works appropriately.